### PR TITLE
Make the absolute footer height and body margin bottom match

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -6,7 +6,7 @@ html {
 }
 
 body {
-  margin-bottom: 60px; /* Margin bottom by footer height */
+  margin-bottom: 160px; /* Margin bottom by footer height */
 }
 
 .footer {


### PR DESCRIPTION
This prevents content from going behind the footer.